### PR TITLE
Take the user choice into account

### DIFF
--- a/bin/git-lab
+++ b/bin/git-lab
@@ -97,6 +97,7 @@ sub get_project_from_config ($config) {
         }
         my $name = $name_for_id{$chosen};
         say "You chose project $name";
+        $project_id = $chosen;
     }
     return $project_id;
 }


### PR DESCRIPTION
Assign the chosen project id to existing `$project_id` variable, that would otherwise never be overwritten. It should help with #9 , an issue that occurs when using a `.git-lab` configuration file with multiple projects.

To reproduce the issue and test the results of the fix, I cloned the repository on gitlab.com and created two forks:

-  [smonff/git-workflow](https://gitlab.com/smonff/git-workflow) that got 2 issues
-  [smonff/git-workflow-2](https://gitlab.com/smonff/git-workflow-2) that got only 1 issue

I used the following configuration. 

```ini
[gitlab]
project_id=45781997
url=https://gitlab.com/api/v4
token=censored

[preferences]
user=sf
max_length=80

[project git-workflow-gitlab-2]
project_id=45781997
[project git-workflow-gitlab]
project_id=45781914

```

I ran various tests, `git lab --current 2` or `git lab --current (1|2)` on each repository and trying the default project too. It was tested with `.git-lab` in `~/` or in the current repository.